### PR TITLE
Add YARP gateway and centralize API routing via Aspire

### DIFF
--- a/src/apphost/Tomeshelf.AppHost/Tomeshelf.AppHost.csproj
+++ b/src/apphost/Tomeshelf.AppHost/Tomeshelf.AppHost.csproj
@@ -22,6 +22,7 @@
 		<PackageReference Include="Aspire.Hosting.Azure" Version="13.1.0" />
 		<PackageReference Include="Aspire.Hosting.Azure.Sql" Version="13.1.0" />
 		<PackageReference Include="Aspire.Hosting.Docker" Version="13.0.2-preview.1.25603.5" />
+		<PackageReference Include="Aspire.Hosting.Yarp" Version="13.1.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.2" />
 	</ItemGroup>
 

--- a/src/service-defaults/Tomeshelf.ServiceDefaults/Extensions.cs
+++ b/src/service-defaults/Tomeshelf.ServiceDefaults/Extensions.cs
@@ -90,16 +90,16 @@ public static class Extensions
     }
 
     /// <summary>
-    ///     Maps default health endpoints used during development.
+    ///     Maps default health endpoints.
     /// </summary>
     /// <param name="app">The web application.</param>
     /// <returns>The same application instance for chaining.</returns>
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
+        app.MapHealthChecks(HealthEndpointPath);
+
         if (app.Environment.IsDevelopment())
         {
-            app.MapHealthChecks(HealthEndpointPath);
-
             app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
         }
 

--- a/src/web/Tomeshelf.Web/Program.cs
+++ b/src/web/Tomeshelf.Web/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
@@ -145,99 +146,122 @@ public class Program
             options.MultipartBodyLengthLimit = 1_073_741_824;
         });
 
+        var gatewayBaseUri = TryResolveGatewayBaseUri(builder);
+
         builder.Services
                .AddHttpClient(GuestsApi.HttpClientName, client =>
-                {
-                    var configured = builder.Configuration["Services:McmApiBase"] ?? builder.Configuration["Services:ApiBase"];
+                 {
+                     if (gatewayBaseUri is not null)
+                     {
+                         client.BaseAddress = new Uri(gatewayBaseUri, "api/mcm/");
+                     }
+                     else
+                     {
+                         var configured = builder.Configuration["Services:McmApiBase"] ?? builder.Configuration["Services:ApiBase"];
 
-                    if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
-                    {
-                        if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
-                        {
-                            throw new InvalidOperationException("Invalid URI in configuration setting 'Services:McmApiBase'.");
-                        }
+                         if (!string.IsNullOrWhiteSpace(configured))
+                         {
+                             if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
+                             {
+                                 throw new InvalidOperationException("Invalid URI in configuration setting 'Services:McmApiBase'.");
+                             }
 
-                        client.BaseAddress = configuredUri;
-                    }
-                    else
-                    {
-                        var protocol = "https";
-                        if (IsRunningInDocker())
-                        {
-                            protocol = "http";
-                        }
+                             client.BaseAddress = configuredUri;
+                         }
+                         else
+                         {
+                             var protocol = "https";
+                             if (IsRunningInDocker())
+                             {
+                                 protocol = "http";
+                             }
 
-                        client.BaseAddress = new Uri($"{protocol}://mcmapi");
-                    }
+                             client.BaseAddress = new Uri($"{protocol}://mcmapi");
+                         }
+                     }
 
-                    client.DefaultRequestVersion = HttpVersion.Version11;
-                    client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
-                    client.Timeout = TimeSpan.FromSeconds(100);
-                })
+                     client.DefaultRequestVersion = HttpVersion.Version11;
+                     client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                     client.Timeout = TimeSpan.FromSeconds(100);
+                 })
                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { AutomaticDecompression = DecompressionMethods.None });
         builder.Services.AddScoped<IGuestsApi, GuestsApi>();
 
         builder.Services
                .AddHttpClient(BundlesApi.HttpClientName, client =>
                 {
-                    var configured = builder.Configuration["Services:HumbleBundleApiBase"];
+                     if (gatewayBaseUri is not null)
+                     {
+                         client.BaseAddress = new Uri(gatewayBaseUri, "api/humblebundle/");
+                     }
+                     else
+                     {
+                         var configured = builder.Configuration["Services:HumbleBundleApiBase"];
 
-                    if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
-                    {
-                        if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
-                        {
-                            throw new InvalidOperationException("Invalid URI in configuration setting 'Services:HumbleBundleApiBase'.");
-                        }
+                         if (!string.IsNullOrWhiteSpace(configured))
+                         {
+                             if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
+                             {
+                                 throw new InvalidOperationException("Invalid URI in configuration setting 'Services:HumbleBundleApiBase'.");
+                             }
 
-                        client.BaseAddress = configuredUri;
-                    }
-                    else
-                    {
-                        var protocol = "https";
-                        if (IsRunningInDocker())
-                        {
-                            protocol = "http";
-                        }
+                             client.BaseAddress = configuredUri;
+                         }
+                         else
+                         {
+                             var protocol = "https";
+                             if (IsRunningInDocker())
+                             {
+                                 protocol = "http";
+                             }
 
-                        client.BaseAddress = new Uri($"{protocol}://humblebundleapi");
-                    }
+                             client.BaseAddress = new Uri($"{protocol}://humblebundleapi");
+                         }
+                     }
 
-                    client.DefaultRequestVersion = HttpVersion.Version11;
-                    client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
-                    client.Timeout = TimeSpan.FromSeconds(100);
-                })
+                     client.DefaultRequestVersion = HttpVersion.Version11;
+                     client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                     client.Timeout = TimeSpan.FromSeconds(100);
+                 })
                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { AutomaticDecompression = DecompressionMethods.None });
         builder.Services.AddScoped<IBundlesApi, BundlesApi>();
 
         builder.Services
                .AddHttpClient(FitbitApi.HttpClientName, client =>
-                {
-                    var configured = builder.Configuration["Services:FitbitApiBase"];
+                 {
+                     if (gatewayBaseUri is not null)
+                     {
+                         client.BaseAddress = gatewayBaseUri;
+                     }
+                     else
+                     {
+                         var configured = builder.Configuration["Services:FitbitApiBase"];
 
-                    if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
-                    {
-                        if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
-                        {
-                            throw new InvalidOperationException("Invalid URI in configuration setting 'Services:FitbitApiBase'.");
-                        }
+                         if (!string.IsNullOrWhiteSpace(configured))
+                         {
+                             if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
+                             {
+                                 throw new InvalidOperationException("Invalid URI in configuration setting 'Services:FitbitApiBase'.");
+                             }
 
-                        client.BaseAddress = configuredUri;
-                    }
-                    else
-                    {
-                        var protocol = "https";
-                        if (IsRunningInDocker())
-                        {
-                            protocol = "http";
-                        }
+                             client.BaseAddress = configuredUri;
+                         }
+                         else
+                         {
+                             var protocol = "https";
+                             if (IsRunningInDocker())
+                             {
+                                 protocol = "http";
+                             }
 
-                        client.BaseAddress = new Uri($"{protocol}://fitbitapi");
-                    }
+                             client.BaseAddress = new Uri($"{protocol}://fitbitapi");
+                         }
+                     }
 
-                    client.DefaultRequestVersion = HttpVersion.Version11;
-                    client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
-                    client.Timeout = TimeSpan.FromSeconds(100);
-                })
+                     client.DefaultRequestVersion = HttpVersion.Version11;
+                     client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                     client.Timeout = TimeSpan.FromSeconds(100);
+                 })
                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
                {
                    AutomaticDecompression = DecompressionMethods.None,
@@ -248,98 +272,119 @@ public class Program
 
         builder.Services
                .AddHttpClient(PaissaApi.HttpClientName, client =>
-                {
-                    var configured = builder.Configuration["Services:PaissaApiBase"];
+                 {
+                     if (gatewayBaseUri is not null)
+                     {
+                         client.BaseAddress = new Uri(gatewayBaseUri, "api/paissa/");
+                     }
+                     else
+                     {
+                         var configured = builder.Configuration["Services:PaissaApiBase"];
 
-                    if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
-                    {
-                        if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
-                        {
-                            throw new InvalidOperationException("Invalid URI in configuration setting 'Services:PaissaApiBase'.");
-                        }
+                         if (!string.IsNullOrWhiteSpace(configured))
+                         {
+                             if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
+                             {
+                                 throw new InvalidOperationException("Invalid URI in configuration setting 'Services:PaissaApiBase'.");
+                             }
 
-                        client.BaseAddress = configuredUri;
-                    }
-                    else
-                    {
-                        var protocol = "https";
-                        if (IsRunningInDocker())
-                        {
-                            protocol = "http";
-                        }
+                             client.BaseAddress = new Uri(EnsureTrailingSlash(configuredUri), "paissa/");
+                         }
+                         else
+                         {
+                             var protocol = "https";
+                             if (IsRunningInDocker())
+                             {
+                                 protocol = "http";
+                             }
 
-                        client.BaseAddress = new Uri($"{protocol}://paissaapi");
-                    }
+                             client.BaseAddress = new Uri($"{protocol}://paissaapi/paissa/");
+                         }
+                     }
 
-                    client.DefaultRequestVersion = HttpVersion.Version11;
-                    client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
-                    client.Timeout = TimeSpan.FromSeconds(30);
-                })
+                     client.DefaultRequestVersion = HttpVersion.Version11;
+                     client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                     client.Timeout = TimeSpan.FromSeconds(30);
+                 })
                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { AutomaticDecompression = DecompressionMethods.None });
         builder.Services.AddScoped<IPaissaApi, PaissaApi>();
 
         builder.Services
                .AddHttpClient(ShiftApi.HttpClientName, client =>
-                {
-                    var configured = builder.Configuration["Services:ShiftApiBase"];
+                 {
+                     if (gatewayBaseUri is not null)
+                     {
+                         client.BaseAddress = new Uri(gatewayBaseUri, "api/shift/");
+                     }
+                     else
+                     {
+                         var configured = builder.Configuration["Services:ShiftApiBase"];
 
-                    if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
-                    {
-                        if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
-                        {
-                            throw new InvalidOperationException("Invalid URI in configuration setting 'Services:ShiftApiBase'.");
-                        }
+                         if (!string.IsNullOrWhiteSpace(configured))
+                         {
+                             if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
+                             {
+                                 throw new InvalidOperationException("Invalid URI in configuration setting 'Services:ShiftApiBase'.");
+                             }
 
-                        client.BaseAddress = configuredUri;
-                    }
-                    else
-                    {
-                        var protocol = "https";
-                        if (IsRunningInDocker())
-                        {
-                            protocol = "http";
-                        }
+                             client.BaseAddress = configuredUri;
+                         }
+                         else
+                         {
+                             var protocol = "https";
+                             if (IsRunningInDocker())
+                             {
+                                 protocol = "http";
+                             }
 
-                        client.BaseAddress = new Uri($"{protocol}://shiftapi");
-                    }
+                             client.BaseAddress = new Uri($"{protocol}://shiftapi");
+                         }
+                     }
 
-                    client.DefaultRequestVersion = HttpVersion.Version11;
-                    client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
-                    client.Timeout = TimeSpan.FromSeconds(30);
-                })
+                     client.DefaultRequestVersion = HttpVersion.Version11;
+                     client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                     client.Timeout = TimeSpan.FromSeconds(30);
+                 })
                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { AutomaticDecompression = DecompressionMethods.None });
         builder.Services.AddScoped<IShiftApi, ShiftApi>();
 
         builder.Services
                .AddHttpClient(FileUploadsApi.HttpClientName, client =>
-                {
-                    var configured = builder.Configuration["Services:FileUploaderApiBase"];
+                 {
+                     if (gatewayBaseUri is not null)
+                     {
+                         client.BaseAddress = new Uri(gatewayBaseUri, "api/fileuploader/");
+                     }
+                     else
+                     {
+                         var configured = builder.Configuration["Services:FileUploaderApiBase"];
 
-                    if (!string.IsNullOrWhiteSpace(configured))
-                    {
-                        if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
-                        {
-                            throw new InvalidOperationException("Invalid URI in configuration setting 'Services:FileUploaderApiBase'.");
-                        }
+                         if (!string.IsNullOrWhiteSpace(configured))
+                         {
+                             if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
+                             {
+                                 throw new InvalidOperationException("Invalid URI in configuration setting 'Services:FileUploaderApiBase'.");
+                             }
 
-                        client.BaseAddress = configuredUri;
-                    }
-                    else
-                    {
-                        if (IsRunningInDocker())
-                        {
-                            client.BaseAddress = new Uri("http://fileuploaderapi");
-                        }
-                        else
-                        {
-                            client.BaseAddress = new Uri("https://localhost:49960");
-                        }
-                    }
+                             client.BaseAddress = configuredUri;
+                         }
+                         else
+                         {
+                             if (IsRunningInDocker())
+                             {
+                                 client.BaseAddress = new Uri("http://fileuploaderapi");
+                             }
+                             else
+                             {
+                                 client.BaseAddress = new Uri("https://localhost:49960");
+                             }
+                         }
+                     }
 
-                    client.DefaultRequestVersion = HttpVersion.Version11;
-                    client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
-                    client.Timeout = TimeSpan.FromMinutes(30);
-                })
+                     client.DefaultRequestVersion = HttpVersion.Version11;
+                     client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                     client.Timeout = TimeSpan.FromMinutes(30);
+                 })
                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { AutomaticDecompression = DecompressionMethods.None })
                .ConfigureHttpMessageHandlerBuilder(b => b.AdditionalHandlers.Clear());
         builder.Services.AddScoped<IFileUploadsApi, FileUploadsApi>();
@@ -402,5 +447,84 @@ public class Program
     private static bool IsRunningInDocker()
     {
         return File.Exists("/.dockerenv");
+    }
+
+    private static Uri? TryResolveGatewayBaseUri(WebApplicationBuilder builder)
+    {
+        var configured = builder.Configuration["Services:GatewayBase"];
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
+            {
+                throw new InvalidOperationException("Invalid URI in configuration setting 'Services:GatewayBase'.");
+            }
+
+            return EnsureTrailingSlash(configuredUri);
+        }
+
+        var discovered = TryGetAspireServiceEndpointUri(builder.Configuration, "gateway");
+        if (discovered is not null)
+        {
+            return EnsureTrailingSlash(discovered);
+        }
+
+        return null;
+    }
+
+    private static Uri? TryGetAspireServiceEndpointUri(IConfiguration configuration, string serviceName)
+    {
+        var serviceSection = configuration.GetSection("services")
+                                          .GetSection(serviceName);
+        if (!serviceSection.Exists())
+        {
+            return null;
+        }
+
+        foreach (var transportName in new[] { "http", "https" })
+        {
+            var transport = serviceSection.GetSection(transportName);
+            if (!transport.Exists())
+            {
+                continue;
+            }
+
+            foreach (var endpointSection in transport.GetChildren())
+            {
+                var rawAddress = endpointSection.Value?.Trim();
+                if (string.IsNullOrWhiteSpace(rawAddress) || !Uri.TryCreate(rawAddress, UriKind.Absolute, out var parsed))
+                {
+                    continue;
+                }
+
+                return parsed;
+            }
+        }
+
+        foreach (var transport in serviceSection.GetChildren())
+        {
+            foreach (var endpointSection in transport.GetChildren())
+            {
+                var rawAddress = endpointSection.Value?.Trim();
+                if (string.IsNullOrWhiteSpace(rawAddress) || !Uri.TryCreate(rawAddress, UriKind.Absolute, out var parsed))
+                {
+                    continue;
+                }
+
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static Uri EnsureTrailingSlash(Uri uri)
+    {
+        var left = uri.GetLeftPart(UriPartial.Path);
+        if (!left.EndsWith("/", StringComparison.Ordinal))
+        {
+            left += "/";
+        }
+
+        return new Uri(left, UriKind.Absolute);
     }
 }

--- a/src/web/Tomeshelf.Web/Program.cs
+++ b/src/web/Tomeshelf.Web/Program.cs
@@ -159,7 +159,7 @@ public class Program
                      {
                          var configured = builder.Configuration["Services:McmApiBase"] ?? builder.Configuration["Services:ApiBase"];
 
-                         if (!string.IsNullOrWhiteSpace(configured))
+                         if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
                          {
                              if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
                              {
@@ -198,7 +198,7 @@ public class Program
                      {
                          var configured = builder.Configuration["Services:HumbleBundleApiBase"];
 
-                         if (!string.IsNullOrWhiteSpace(configured))
+                         if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
                          {
                              if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
                              {
@@ -237,7 +237,7 @@ public class Program
                      {
                          var configured = builder.Configuration["Services:FitbitApiBase"];
 
-                         if (!string.IsNullOrWhiteSpace(configured))
+                         if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
                          {
                              if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
                              {
@@ -273,34 +273,34 @@ public class Program
         builder.Services
                .AddHttpClient(PaissaApi.HttpClientName, client =>
                  {
-                     if (gatewayBaseUri is not null)
-                     {
-                         client.BaseAddress = new Uri(gatewayBaseUri, "api/paissa/");
-                     }
-                     else
-                     {
-                         var configured = builder.Configuration["Services:PaissaApiBase"];
+                      if (gatewayBaseUri is not null)
+                      {
+                          client.BaseAddress = new Uri(gatewayBaseUri, "api/");
+                      }
+                      else
+                      {
+                          var configured = builder.Configuration["Services:PaissaApiBase"];
 
-                         if (!string.IsNullOrWhiteSpace(configured))
-                         {
-                             if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
-                             {
-                                 throw new InvalidOperationException("Invalid URI in configuration setting 'Services:PaissaApiBase'.");
-                             }
+                          if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
+                          {
+                              if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
+                              {
+                                  throw new InvalidOperationException("Invalid URI in configuration setting 'Services:PaissaApiBase'.");
+                              }
 
-                             client.BaseAddress = new Uri(EnsureTrailingSlash(configuredUri), "paissa/");
-                         }
-                         else
-                         {
-                             var protocol = "https";
-                             if (IsRunningInDocker())
-                             {
-                                 protocol = "http";
-                             }
+                              client.BaseAddress = configuredUri;
+                          }
+                          else
+                          {
+                              var protocol = "https";
+                              if (IsRunningInDocker())
+                              {
+                                  protocol = "http";
+                              }
 
-                             client.BaseAddress = new Uri($"{protocol}://paissaapi/paissa/");
-                         }
-                     }
+                              client.BaseAddress = new Uri($"{protocol}://paissaapi");
+                          }
+                      }
 
                      client.DefaultRequestVersion = HttpVersion.Version11;
                      client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
@@ -320,7 +320,7 @@ public class Program
                      {
                          var configured = builder.Configuration["Services:ShiftApiBase"];
 
-                         if (!string.IsNullOrWhiteSpace(configured))
+                         if (!string.IsNullOrWhiteSpace(configured) && !builder.Environment.IsDevelopment())
                          {
                              if (!Uri.TryCreate(configured, UriKind.Absolute, out var configuredUri))
                              {

--- a/src/web/Tomeshelf.Web/Services/PaissaApi.cs
+++ b/src/web/Tomeshelf.Web/Services/PaissaApi.cs
@@ -23,7 +23,7 @@ public sealed class PaissaApi : IPaissaApi
 
     public async Task<PaissaWorldModel> GetWorldAsync(CancellationToken cancellationToken)
     {
-        const string url = "world";
+        const string url = "paissa/world";
         var started = DateTimeOffset.UtcNow;
 
         using var response = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);

--- a/src/web/Tomeshelf.Web/Services/PaissaApi.cs
+++ b/src/web/Tomeshelf.Web/Services/PaissaApi.cs
@@ -23,7 +23,7 @@ public sealed class PaissaApi : IPaissaApi
 
     public async Task<PaissaWorldModel> GetWorldAsync(CancellationToken cancellationToken)
     {
-        const string url = "paissa/world";
+        const string url = "world";
         var started = DateTimeOffset.UtcNow;
 
         using var response = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);

--- a/tests/web/Tomeshelf.Web.Tests/ProgramTests/BuildApp.cs
+++ b/tests/web/Tomeshelf.Web.Tests/ProgramTests/BuildApp.cs
@@ -121,6 +121,35 @@ public class BuildApp
         uploads.BaseAddress.ShouldBe(new Uri("https://uploads.example.test/"));
     }
 
+    [Fact]
+    public void WhenGatewayConfigured_UsesGatewayAddresses()
+    {
+        // Arrange
+        var config = new Dictionary<string, string?>
+        {
+            ["Services:GatewayBase"] = "https://gateway.example.test/"
+        };
+
+        using var app = ProgramTestHarness.BuildApp(Environments.Production, config);
+        var factory = app.Services.GetRequiredService<IHttpClientFactory>();
+
+        // Act
+        var guests = factory.CreateClient(GuestsApi.HttpClientName);
+        var bundles = factory.CreateClient(BundlesApi.HttpClientName);
+        var fitbit = factory.CreateClient(FitbitApi.HttpClientName);
+        var paissa = factory.CreateClient(PaissaApi.HttpClientName);
+        var shift = factory.CreateClient(ShiftApi.HttpClientName);
+        var uploads = factory.CreateClient(FileUploadsApi.HttpClientName);
+
+        // Assert
+        guests.BaseAddress.ShouldBe(new Uri("https://gateway.example.test/api/mcm/"));
+        bundles.BaseAddress.ShouldBe(new Uri("https://gateway.example.test/api/humblebundle/"));
+        fitbit.BaseAddress.ShouldBe(new Uri("https://gateway.example.test/"));
+        paissa.BaseAddress.ShouldBe(new Uri("https://gateway.example.test/api/"));
+        shift.BaseAddress.ShouldBe(new Uri("https://gateway.example.test/api/shift/"));
+        uploads.BaseAddress.ShouldBe(new Uri("https://gateway.example.test/api/fileuploader/"));
+    }
+
     [Theory]
     [MemberData(nameof(InvalidServiceUris))]
     public void WhenInvalidUriConfigured_Throws(string key, string clientName, string message)


### PR DESCRIPTION
This pull request introduces a new YARP-powered API gateway to centralize and streamline routing between the web frontend and backend APIs. The web application is updated to route all API requests through this gateway, simplifying service discovery and configuration. The changes also add logic to dynamically resolve the gateway's base URI in various deployment environments, and update HTTP client configurations accordingly.

**API Gateway Introduction and Routing**

- Added a new YARP-based gateway service in `Program.cs` (`Tomeshelf.AppHost`) that routes requests to all backend APIs, with path transforms for each API and health checks, and ensures service dependencies are respected.
- Updated the web frontend setup to depend on the new gateway instead of directly referencing each API, streamlining deployment and service orchestration. [[1]](diffhunk://#diff-964f90cdfc0f2be68e7b3dcb9876c633dc1fe0fa95d72fbb96a3343ed4fd7c7aR51-R54) [[2]](diffhunk://#diff-964f90cdfc0f2be68e7b3dcb9876c633dc1fe0fa95d72fbb96a3343ed4fd7c7aL329-R387) [[3]](diffhunk://#diff-964f90cdfc0f2be68e7b3dcb9876c633dc1fe0fa95d72fbb96a3343ed4fd7c7aL364-R423)

**Web Application HTTP Client Configuration**

- Refactored all API HTTP client registrations in `Tomeshelf.Web` to use the gateway base URI if available, falling back to configuration or service discovery if not. Each client now targets the appropriate gateway route (e.g., `/api/mcm/`, `/api/humblebundle/`, etc.). [[1]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR149-R162) [[2]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR181) [[3]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR192-R201) [[4]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR220) [[5]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR231-R240) [[6]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR259) [[7]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR275-R291) [[8]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fL271-R302) [[9]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR314-R323) [[10]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR342) [[11]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR353-R358) [[12]](diffhunk://#diff-718d8ce5b0a5acb6b74e292afbe28ce6baf9545b864685ae8cb926f4124fa83fR382)

**Service Discovery and Gateway URI Resolution**

- Added helper methods to resolve the gateway's base URI from configuration or service discovery, ensuring robust operation across different deployment scenarios.

**Dependency and Package Updates**

- Added a dependency on `Aspire.Hosting.Yarp` in the app host project to support the new gateway functionality.

**Minor API Path Correction**

- Fixed the `PaissaApi` service to use the correct relative path (`world` instead of `paissa/world`) now that requests are routed through the gateway and path prefixes are handled there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized API gateway now exposes backend services behind unified gateway paths, consolidating routing.
  * HTTP client configuration unified to prefer gateway-based base URLs, falling back to existing service endpoints when unavailable.
  * Service endpoints now resolve consistently through the gateway, affecting how API requests are addressed.

* **Tests**
  * Added test coverage to verify clients use gateway-prefixed addresses when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->